### PR TITLE
Use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Tiny Vue Team",
   "repository": {
     "type": "git",
-    "url": "git@github.com:opentiny/unplugin-tiny-vue.git"
+    "url": "git+https://github.com/opentiny/unplugin-tiny-vue.git"
   },
   "keywords": [
     "vite-plugin",


### PR DESCRIPTION
## Summary
- update package repository metadata to use the public HTTPS GitHub URL instead of SSH

## Validation
- node metadata assertion
- git diff --check
- git ls-remote https://github.com/opentiny/unplugin-tiny-vue.git HEAD
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm build
- pnpm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

**No user-facing changes**

This release contains only infrastructure updates with no impact on product features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->